### PR TITLE
feat: Update loadTLSConfig to return CommonName and adjust tests acco…

### DIFF
--- a/mqttclient.go
+++ b/mqttclient.go
@@ -39,6 +39,14 @@ func loadTLSConfig(caFile string, clientFile string, keyFile string) (*tls.Confi
 		if err != nil {
 			return nil, CommonName, err
 		}
+		// Parse the certificate to populate the Leaf field
+		if len(cert.Certificate) > 0 {
+			leaf, err := x509.ParseCertificate(cert.Certificate[0])
+			if err != nil {
+				return nil, CommonName, err
+			}
+			cert.Leaf = leaf
+		}
 		CommonName = cert.Leaf.Subject.CommonName
 		tlsConfig.RootCAs = rootCAs
 		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert

--- a/mqttclient_test.go
+++ b/mqttclient_test.go
@@ -47,7 +47,7 @@ func generateTestCerts(caFile, clientFile, keyFile string) error {
 	// Generate client certificate
 	client := &x509.Certificate{
 		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{Organization: []string{"Test Client"}},
+		Subject:      pkix.Name{Organization: []string{"Test CA"}, CommonName: "Test Client"},
 		NotBefore:    time.Now(),
 		NotAfter:     time.Now().AddDate(1, 0, 0),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
@@ -95,12 +95,15 @@ func TestLoadTLSConfig(t *testing.T) {
 	defer os.Remove(clientFile) //nolint:errcheck
 	defer os.Remove(keyFile)    //nolint:errcheck
 
-	tlsConfig, err := loadTLSConfig(caFile, clientFile, keyFile)
+	tlsConfig, name, err := loadTLSConfig(caFile, clientFile, keyFile)
 	if err != nil {
 		t.Fatalf("failed to load TLS config: %v", err)
 	}
 	if tlsConfig == nil {
 		t.Fatal("expected tlsConfig to be created, got nil")
+	}
+	if name != "Test Client" {
+		t.Errorf("expected CommonName to be 'Test Client', got '%s'", name)
 	}
 
 	if len(tlsConfig.Certificates) != 1 {


### PR DESCRIPTION
This pull request updates the TLS configuration logic in the MQTT client to extract and use the client certificate's Common Name as the MQTT username. It also updates the test certificates and test cases to verify this behavior.

TLS configuration and client identity:

* The `loadTLSConfig` function now returns the client certificate's Common Name in addition to the TLS config and error, and sets this Common Name as the MQTT connection username in `createClient`. [[1]](diffhunk://#diff-9beb5f3e1244a5a9f018d1de14a5ea516736bef899ef16fb0dcf38d2c6581897L17-R21) [[2]](diffhunk://#diff-9beb5f3e1244a5a9f018d1de14a5ea516736bef899ef16fb0dcf38d2c6581897L39-R51) [[3]](diffhunk://#diff-9beb5f3e1244a5a9f018d1de14a5ea516736bef899ef16fb0dcf38d2c6581897R76)

Testing improvements:

* The test certificate generation now sets the Common Name to "Test Client", and the test for `loadTLSConfig` verifies that the Common Name is extracted correctly. [[1]](diffhunk://#diff-5688a2c995b20d6dbcc8232e230c9d150f36d1b978851204c1001edc07cfdb58L50-R50) [[2]](diffhunk://#diff-5688a2c995b20d6dbcc8232e230c9d150f36d1b978851204c1001edc07cfdb58L98-R107)…rdingly