### PR TITLE
feat: Add solar inverter MQTT message routing to InfluxDB buckets (#7)

### DIFF
--- a/message_handler.go
+++ b/message_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/eclipse/paho.golang/paho"
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	"github.com/influxdata/influxdb-client-go/v2/api"
 )
 
 // handler is a simple struct that provides a function to be called when a message is received. The message is parsed
@@ -172,14 +173,15 @@ func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization
 		return
 	}
 
-	// Write all points first, then flush each WriteAPI once to reduce network overhead.
+	writeAPIs := make(map[string]api.WriteAPI)
 	for bucket, influxMsg := range points {
 		writeAPI := client.WriteAPI(organization, bucket)
+		writeAPIs[bucket] = writeAPI
 		p := influxdb2.NewPoint(influxMsg.Measurement, influxMsg.Tags, influxMsg.Fields, influxMsg.Time)
 		writeAPI.WritePoint(p)
 	}
-	for bucket := range points {
-		client.WriteAPI(organization, bucket).Flush()
+	for _, writeAPI := range writeAPIs {
+		writeAPI.Flush()
 	}
 }
 

--- a/message_handler.go
+++ b/message_handler.go
@@ -69,9 +69,125 @@ func toInfluxMessage(measurement string, location string, sensorId string, messa
 	}
 }
 
+type solarMessage struct {
+	Model     string                 `json:"model"`
+	Data      map[string]interface{} `json:"data"`
+	Timestamp float64                `json:"timestamp"`
+	Source    string                 `json:"source"`
+}
+
+// solarTagKeys is the explicit allowlist of data fields that should be stored as InfluxDB tags.
+var solarTagKeys = map[string]bool{
+	"status":           true,
+	"model_id":         true,
+	"model_length":     true,
+	"status_vendor_16": true,
+	"status_vendor_32": true,
+	"status_code":      true,
+}
+
+// classifySolarField maps a data field key to its target InfluxDB bucket.
+// Returns "tag" for fields that should be stored as tags instead of measurement fields.
+// Returns "" for unknown fields that should be skipped.
+func classifySolarField(key string) string {
+	if solarTagKeys[key] {
+		return "tag"
+	}
+	switch {
+	case strings.HasSuffix(key, "_wh"):
+		return "latest_energy"
+	case strings.HasSuffix(key, "_w") || strings.HasSuffix(key, "_va") ||
+		strings.HasSuffix(key, "_var") || strings.HasSuffix(key, "_pct"):
+		return "latest_energy_current"
+	case strings.HasPrefix(key, "ac_current_") || strings.HasPrefix(key, "ac_voltage_") ||
+		strings.HasPrefix(key, "dc_current_") || strings.HasPrefix(key, "dc_voltage_") ||
+		strings.HasSuffix(key, "_hz"):
+		return "latest_voltage_current"
+	case strings.HasPrefix(key, "temp_"):
+		return "sensors"
+	default:
+		return ""
+	}
+}
+
+// buildSolarPoints parses a raw solar MQTT payload and returns a map of
+// bucket name → InfluxMessage ready for writing. Only buckets with at least
+// one field are included in the result.
+func buildSolarPoints(payload []byte) (map[string]InfluxMessage, error) {
+	var solar solarMessage
+	if err := json.Unmarshal(payload, &solar); err != nil {
+		return nil, err
+	}
+
+	sec := int64(solar.Timestamp)
+	nsec := int64((solar.Timestamp - float64(sec)) * 1e9)
+	timestamp := time.Unix(sec, nsec)
+
+	tags := map[string]string{
+		"model":  solar.Model,
+		"source": solar.Source,
+	}
+
+	buckets := map[string]map[string]interface{}{
+		"latest_energy":          {},
+		"latest_energy_current":  {},
+		"latest_voltage_current": {},
+		"sensors":                {},
+	}
+
+	for key, val := range solar.Data {
+		if val == nil {
+			continue
+		}
+		bucket := classifySolarField(key)
+		switch bucket {
+		case "tag":
+			tags[key] = fmt.Sprintf("%v", val)
+		case "":
+			fmt.Printf("Unknown solar field %q, skipping\n", key)
+		default:
+			buckets[bucket][key] = val
+		}
+	}
+
+	result := make(map[string]InfluxMessage)
+	for bucket, fields := range buckets {
+		if len(fields) == 0 {
+			continue
+		}
+		result[bucket] = InfluxMessage{
+			Measurement: solar.Source,
+			Tags:        tags,
+			Fields:      fields,
+			Time:        timestamp,
+		}
+	}
+	return result, nil
+}
+
+func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization string) {
+	points, err := buildSolarPoints(msg.Payload)
+	if err != nil {
+		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
+		return
+	}
+
+	// Write all points first, then flush each WriteAPI once to reduce network overhead.
+	for bucket, influxMsg := range points {
+		writeAPI := client.WriteAPI(organization, bucket)
+		p := influxdb2.NewPoint(influxMsg.Measurement, influxMsg.Tags, influxMsg.Fields, influxMsg.Time)
+		writeAPI.WritePoint(p)
+	}
+	for bucket := range points {
+		client.WriteAPI(organization, bucket).Flush()
+	}
+}
+
 // handle is called when a message is received
 func (o *handler) handle(msg *paho.Publish) {
-	if strings.Contains(msg.Topic, "p1") {
+	if strings.HasPrefix(msg.Topic, "solaredge/") {
+		handleSolarMessage(msg, o.client, o.organization)
+	} else if strings.Contains(msg.Topic, "p1") {
 		var p1Message InfluxMessage
 		err := json.Unmarshal(msg.Payload, &p1Message)
 		if err != nil {

--- a/solar_handler_test.go
+++ b/solar_handler_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/eclipse/paho.golang/paho"
+)
+
+func TestClassifySolarField(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		// Energy bucket
+		{"ac_energy_wh", "latest_energy"},
+		// Power bucket
+		{"ac_power_w", "latest_energy_current"},
+		{"dc_power_w", "latest_energy_current"},
+		{"ac_apparent_power_va", "latest_energy_current"},
+		{"ac_reactive_power_var", "latest_energy_current"},
+		{"ac_power_factor_pct", "latest_energy_current"},
+		// Voltage/current/frequency bucket
+		{"ac_current_a", "latest_voltage_current"},
+		{"ac_current_b", "latest_voltage_current"},
+		{"ac_current_c", "latest_voltage_current"},
+		{"ac_current_total", "latest_voltage_current"},
+		{"ac_voltage_ab", "latest_voltage_current"},
+		{"ac_voltage_an", "latest_voltage_current"},
+		{"ac_frequency_hz", "latest_voltage_current"},
+		{"dc_current_a", "latest_voltage_current"},
+		{"dc_voltage_v", "latest_voltage_current"},
+		// Temperature bucket
+		{"temp_sink_c", "sensors"},
+		// Tags
+		{"model_id", "tag"},
+		{"model_length", "tag"},
+		{"status", "tag"},
+		{"status_vendor_16", "tag"},
+		{"status_vendor_32", "tag"},
+		{"status_code", "tag"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			got := classifySolarField(tt.key)
+			if got != tt.expected {
+				t.Errorf("classifySolarField(%q) = %q, want %q", tt.key, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestHandleSolarMessage_ParsesAndRoutesFields(t *testing.T) {
+	payload := map[string]interface{}{
+		"model": "SE2200H/inverter",
+		"data": map[string]interface{}{
+			"model_id":              101,
+			"model_length":          50,
+			"ac_current_a":          4.8,
+			"ac_current_b":          nil,
+			"ac_power_w":            1154.0,
+			"ac_apparent_power_va":  1158.1,
+			"ac_reactive_power_var": 97.7,
+			"ac_power_factor_pct":   99.64,
+			"ac_energy_wh":          6679718.0,
+			"dc_current_a":          3.172,
+			"dc_voltage_v":          369.3,
+			"dc_power_w":            1171.6,
+			"ac_frequency_hz":       49.966,
+			"ac_voltage_an":         240.6,
+			"temp_sink_c":           45.14,
+			"status":                "MPPT",
+			"status_vendor_16":      0,
+			"status_vendor_32":      0,
+			"status_code":           4,
+		},
+		"timestamp": 1779634500.6994448,
+		"source":    "SE2200H",
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+
+	written, err := buildSolarPoints(payloadBytes)
+	if err != nil {
+		t.Fatalf("buildSolarPoints failed: %v", err)
+	}
+
+	// Verify all 4 buckets received data
+	for _, bucket := range []string{"latest_energy", "latest_energy_current", "latest_voltage_current", "sensors"} {
+		if _, ok := written[bucket]; !ok {
+			t.Errorf("expected data written to bucket %q, but got nothing", bucket)
+		}
+	}
+
+	// Verify specific field routing
+	if _, ok := written["latest_energy"].Fields["ac_energy_wh"]; !ok {
+		t.Error("expected ac_energy_wh in latest_energy bucket")
+	}
+	if _, ok := written["latest_energy_current"].Fields["ac_power_w"]; !ok {
+		t.Error("expected ac_power_w in latest_energy_current bucket")
+	}
+	if _, ok := written["latest_voltage_current"].Fields["ac_current_a"]; !ok {
+		t.Error("expected ac_current_a in latest_voltage_current bucket")
+	}
+	if _, ok := written["sensors"].Fields["temp_sink_c"]; !ok {
+		t.Error("expected temp_sink_c in sensors bucket")
+	}
+
+	// Verify null field (ac_current_b) was skipped
+	if _, ok := written["latest_voltage_current"].Fields["ac_current_b"]; ok {
+		t.Error("ac_current_b was null, should not be in fields")
+	}
+
+	// Verify tags are present with expected values
+	if written["latest_energy"].Tags["model"] != "SE2200H/inverter" {
+		t.Errorf("expected tag model=SE2200H/inverter, got %q", written["latest_energy"].Tags["model"])
+	}
+	if written["latest_energy"].Tags["source"] != "SE2200H" {
+		t.Errorf("expected tag source=SE2200H, got %q", written["latest_energy"].Tags["source"])
+	}
+	if written["latest_energy"].Tags["status"] != "MPPT" {
+		t.Errorf("expected tag status=MPPT, got %q", written["latest_energy"].Tags["status"])
+	}
+
+	// Verify measurement name is the source
+	if written["latest_energy"].Measurement != "SE2200H" {
+		t.Errorf("expected measurement SE2200H, got %q", written["latest_energy"].Measurement)
+	}
+}
+
+func TestHandleSolarMessage_InvalidPayload(t *testing.T) {
+	// Should not panic on invalid payload
+	msg := &paho.Publish{
+		Topic:   "solaredge/SE2200H/inverter",
+		Payload: []byte("not-valid-json"),
+	}
+	// handleSolarMessage prints error but must not panic
+	handleSolarMessage(msg, nil, "test-org")
+}

--- a/solar_handler_test.go
+++ b/solar_handler_test.go
@@ -51,7 +51,7 @@ func TestClassifySolarField(t *testing.T) {
 	}
 }
 
-func TestHandleSolarMessage_ParsesAndRoutesFields(t *testing.T) {
+func TestBuildSolarPoints_ParsesAndRoutesFields(t *testing.T) {
 	payload := map[string]interface{}{
 		"model": "SE2200H/inverter",
 		"data": map[string]interface{}{


### PR DESCRIPTION
* Add solar message handling: parse solaredge topics and route fields to 4 InfluxDB buckets

* fix: address all review comments - topic routing, tag allowlist, batch writes, bucket rename, test refactor

---------