### PR TITLE
fix: set-solar values into kW and kWh

### DIFF
--- a/message_handler.go
+++ b/message_handler.go
@@ -111,6 +111,22 @@ func classifySolarField(key string) string {
 	}
 }
 
+func transformSolarValue(key string, val interface{}) (string, interface{}) {
+	switch {
+	case strings.HasSuffix(key, "_wh"):
+		// convert watt-hour values to kilowatt-hours and rename accordingly
+		if num, ok := val.(float64); ok {
+			return strings.TrimSuffix(key, "_wh") + "_kwh", num / 1000
+		}
+	case strings.HasSuffix(key, "_w"):
+		// convert watt values to kilowatts and rename accordingly
+		if num, ok := val.(float64); ok {
+			return strings.TrimSuffix(key, "_w") + "_kw", num / 1000
+		}
+	}
+	return key, val
+}
+
 // buildSolarPoints parses a raw solar MQTT payload and returns a map of
 // bucket name → InfluxMessage ready for writing. Only buckets with at least
 // one field are included in the result.
@@ -147,7 +163,8 @@ func buildSolarPoints(payload []byte) (map[string]InfluxMessage, error) {
 		case "":
 			fmt.Printf("Unknown solar field %q, skipping\n", key)
 		default:
-			buckets[bucket][key] = val
+			newKey, transformValue := transformSolarValue(key, val)
+			buckets[bucket][newKey] = transformValue
 		}
 	}
 

--- a/solar_handler_test.go
+++ b/solar_handler_test.go
@@ -96,12 +96,12 @@ func TestBuildSolarPoints_ParsesAndRoutesFields(t *testing.T) {
 		}
 	}
 
-	// Verify specific field routing
-	if _, ok := written["latest_energy"].Fields["ac_energy_wh"]; !ok {
-		t.Error("expected ac_energy_wh in latest_energy bucket")
+	// Verify specific field routing (watt fields are renamed on transformation)
+	if _, ok := written["latest_energy"].Fields["ac_energy_kwh"]; !ok {
+		t.Error("expected ac_energy_kwh in latest_energy bucket")
 	}
-	if _, ok := written["latest_energy_current"].Fields["ac_power_w"]; !ok {
-		t.Error("expected ac_power_w in latest_energy_current bucket")
+	if _, ok := written["latest_energy_current"].Fields["ac_power_kw"]; !ok {
+		t.Error("expected ac_power_kw in latest_energy_current bucket")
 	}
 	if _, ok := written["latest_voltage_current"].Fields["ac_current_a"]; !ok {
 		t.Error("expected ac_current_a in latest_voltage_current bucket")
@@ -140,4 +140,86 @@ func TestHandleSolarMessage_InvalidPayload(t *testing.T) {
 	}
 	// handleSolarMessage prints error but must not panic
 	handleSolarMessage(msg, nil, "test-org")
+}
+
+func TestTransformSolarValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         string
+		val         interface{}
+		expectedKey string
+		expectedVal interface{}
+	}{
+		{"watt suffix converts to kW", "ac_power_w", float64(1000), "ac_power_kw", float64(1)},
+		{"wh suffix converts to kWh", "ac_energy_wh", float64(6000), "ac_energy_kwh", float64(6)},
+		{"fractional watt", "dc_power_w", float64(1500), "dc_power_kw", float64(1.5)},
+		{"zero watt", "ac_power_w", float64(0), "ac_power_kw", float64(0)},
+		{"non-numeric watt key renamed but val unchanged", "ac_power_w", "string-val", "ac_power_w", "string-val"},
+		{"non-watt key unchanged", "temp_sink_c", float64(45.14), "temp_sink_c", float64(45.14)},
+		{"va value unchanged", "ac_apparent_power_va", float64(1158.1), "ac_apparent_power_va", float64(1158.1)},
+		{"non-watt string unchanged", "status", "MPPT", "status", "MPPT"},
+		{"nil unchanged", "ac_power_w", nil, "ac_power_w", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotKey, gotVal := transformSolarValue(tt.key, tt.val)
+			if gotKey != tt.expectedKey {
+				t.Errorf("transformSolarValue(%q, %v) key = %q, want %q", tt.key, tt.val, gotKey, tt.expectedKey)
+			}
+			if gotVal != tt.expectedVal {
+				t.Errorf("transformSolarValue(%q, %v) val = %v, want %v", tt.key, tt.val, gotVal, tt.expectedVal)
+			}
+		})
+	}
+}
+
+func TestBuildSolarPoints_WattValuesConvertedToKilowatt(t *testing.T) {
+	payload := map[string]interface{}{
+		"model": "SE2200H/inverter",
+		"data": map[string]interface{}{
+			"ac_power_w":   float64(2000),
+			"ac_energy_wh": float64(5000000),
+			"temp_sink_c":  float64(45.0),
+		},
+		"timestamp": float64(1779634500),
+		"source":    "SE2200H",
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal test payload: %v", err)
+	}
+
+	points, err := buildSolarPoints(payloadBytes)
+	if err != nil {
+		t.Fatalf("buildSolarPoints failed: %v", err)
+	}
+
+	// ac_power_w (2000 W) should be stored as 2.0 under the renamed key ac_power_kw
+	pwBucket, ok := points["latest_energy_current"]
+	if !ok {
+		t.Fatal("expected latest_energy_current bucket")
+	}
+	if pwBucket.Fields["ac_power_kw"] != float64(2) {
+		t.Errorf("expected ac_power_kw=2.0 (kW), got %v", pwBucket.Fields["ac_power_kw"])
+	}
+
+	// ac_energy_wh (5_000_000 Wh) should be stored as 5000.0 under the renamed key ac_energy_kwh
+	energyBucket, ok := points["latest_energy"]
+	if !ok {
+		t.Fatal("expected latest_energy bucket")
+	}
+	if energyBucket.Fields["ac_energy_kwh"] != float64(5000) {
+		t.Errorf("expected ac_energy_kwh=5000.0 (kWh), got %v", energyBucket.Fields["ac_energy_kwh"])
+	}
+
+	// temp_sink_c should be unchanged
+	sensorBucket, ok := points["sensors"]
+	if !ok {
+		t.Fatal("expected sensors bucket")
+	}
+	if sensorBucket.Fields["temp_sink_c"] != float64(45.0) {
+		t.Errorf("expected temp_sink_c=45.0 unchanged, got %v", sensorBucket.Fields["temp_sink_c"])
+	}
 }

--- a/solar_handler_test.go
+++ b/solar_handler_test.go
@@ -154,7 +154,7 @@ func TestTransformSolarValue(t *testing.T) {
 		{"wh suffix converts to kWh", "ac_energy_wh", float64(6000), "ac_energy_kwh", float64(6)},
 		{"fractional watt", "dc_power_w", float64(1500), "dc_power_kw", float64(1.5)},
 		{"zero watt", "ac_power_w", float64(0), "ac_power_kw", float64(0)},
-		{"non-numeric watt key renamed but val unchanged", "ac_power_w", "string-val", "ac_power_w", "string-val"},
+		{"non-numeric watt key unchanged", "ac_power_w", "string-val", "ac_power_w", "string-val"},
 		{"non-watt key unchanged", "temp_sink_c", float64(45.14), "temp_sink_c", float64(45.14)},
 		{"va value unchanged", "ac_apparent_power_va", float64(1158.1), "ac_apparent_power_va", float64(1158.1)},
 		{"non-watt string unchanged", "status", "MPPT", "status", "MPPT"},


### PR DESCRIPTION
This pull request introduces a new transformation step for solar measurement fields, converting watt and watt-hour values to kilowatts and kilowatt-hours, respectively, and updating their keys accordingly. It also adds comprehensive unit tests to verify the transformation logic and updates existing tests to reflect the new behavior.

**Solar value transformation:**

* Added the `transformSolarValue` function in `message_handler.go` to automatically convert fields ending in `_w` to kilowatts (`_kw`) and `_wh` to kilowatt-hours (`_kwh`), updating both the field names and values as appropriate.
* Updated the `buildSolarPoints` function to apply `transformSolarValue` to all relevant fields before storing them in buckets.

**Testing improvements:**

* Updated existing tests in `solar_handler_test.go` to check for the new key names (`ac_power_kw`, `ac_energy_kwh`) instead of the original watt-based keys.
* Added a new test, `TestTransformSolarValue`, to verify that the transformation logic works correctly for various cases, including numeric and non-numeric values, and fields that should not be transformed.
* Added another test, `TestBuildSolarPoints_WattValuesConvertedToKilowatt`, to ensure that the transformation is integrated correctly into the solar point-building pipeline, verifying both the conversion and renaming of keys and values.