### PR TITLE
feat: Added support for Victron Monitoring messages

### DIFF
--- a/message_handler.go
+++ b/message_handler.go
@@ -44,8 +44,8 @@ func splitTopic(topic string) (string, string, error) {
 }
 
 type genericPayloadMessage struct {
-	value float64   `json:"value"`
-	time  time.Time `json:"time"`
+	Value     float64 `json:"value"`
+	Timestamp int64   `json:"timestamp"`
 }
 
 type sensorMessage struct {
@@ -188,6 +188,44 @@ func buildSolarPoints(payload []byte) (map[string]InfluxMessage, error) {
 	return result, nil
 }
 
+func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, error) {
+	var victronMessage genericPayloadMessage
+	if err := json.Unmarshal(payload, &victronMessage); err != nil {
+		return "", InfluxMessage{}, err
+	}
+
+	splitTopic := strings.Split(topic, "/")
+	if len(splitTopic) < 3 {
+		return "", InfluxMessage{}, fmt.Errorf("topic is not in the correct format: %s", topic)
+	}
+
+	bucket := splitTopic[0]
+	serviceType := splitTopic[2]
+	deviceInstance := ""
+	if len(splitTopic) > 3 {
+		deviceInstance = splitTopic[3]
+	}
+
+	fieldKey := "value"
+	if len(splitTopic) > 4 {
+		fieldKey = strings.Join(splitTopic[4:], "/")
+	}
+
+	point := InfluxMessage{
+		Measurement: serviceType,
+		Tags: map[string]string{
+			"VRM_Portal_ID":   splitTopic[1],
+			"Device_Instance": deviceInstance,
+		},
+		Fields: map[string]interface{}{
+			fieldKey: victronMessage.Value,
+		},
+		Time: time.UnixMilli(victronMessage.Timestamp),
+	}
+
+	return bucket, point, nil
+}
+
 func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization string) {
 	points, err := buildSolarPoints(msg.Payload)
 	if err != nil {
@@ -244,29 +282,10 @@ func (o *handler) handle(msg *paho.Publish) {
 
 		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
 	} else if strings.Contains(msg.Topic, "victron") {
-		var victronMessage genericPayloadMessage
-		err := json.Unmarshal(msg.Payload, &victronMessage)
+		bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
 		if err != nil {
-			fmt.Printf("Message could not be parsed (%s): %s", msg.Payload, err)
-		}
-		splitTopic := strings.Split(msg.Topic, "/")
-		if len(splitTopic) < 7 {
-			fmt.Printf("Topic is not in the correct format: %s", msg.Topic)
+			fmt.Printf("Victron message could not be parsed (%s): %s", msg.Payload, err)
 			return
-		}
-		bucket, measurement := splitTopic[0], splitTopic[2]
-		tags := map[string]string{
-			"DeviceID": splitTopic[1],
-			"Phase":    splitTopic[5],
-		}
-		fields := map[string]interface{}{
-			splitTopic[6]: victronMessage.value,
-		}
-		victronInfluxMessage := InfluxMessage{
-			Measurement: measurement,
-			Tags:        tags,
-			Fields:      fields,
-			Time:        time.Now(),
 		}
 		writePoint(bucket, victronInfluxMessage, o.client, o.organization)
 

--- a/message_handler.go
+++ b/message_handler.go
@@ -214,8 +214,8 @@ func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, err
 	point := InfluxMessage{
 		Measurement: serviceType,
 		Tags: map[string]string{
-			"VRM_Portal_ID":   splitTopic[1],
-			"Device_Instance": deviceInstance,
+			"vrm_portal_id":   splitTopic[1],
+			"device_instance": deviceInstance,
 		},
 		Fields: map[string]interface{}{
 			fieldKey: victronMessage.Value,

--- a/message_handler.go
+++ b/message_handler.go
@@ -43,6 +43,11 @@ func splitTopic(topic string) (string, string, error) {
 	return mainTopic, subTopic, nil
 }
 
+type genericPayloadMessage struct {
+	value float64   `json:"value"`
+	time  time.Time `json:"time"`
+}
+
 type sensorMessage struct {
 	Unit      string    `json:"unit"`
 	Value     float64   `json:"value"`
@@ -238,6 +243,33 @@ func (o *handler) handle(msg *paho.Publish) {
 		sensorInfluxMessage := toInfluxMessage(measurement, location, sensorId, sensorMessage)
 
 		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
+	} else if strings.Contains(msg.Topic, "victron") {
+		var victronMessage genericPayloadMessage
+		err := json.Unmarshal(msg.Payload, &victronMessage)
+		if err != nil {
+			fmt.Printf("Message could not be parsed (%s): %s", msg.Payload, err)
+		}
+		splitTopic := strings.Split(msg.Topic, "/")
+		if len(splitTopic) < 7 {
+			fmt.Printf("Topic is not in the correct format: %s", msg.Topic)
+			return
+		}
+		bucket, measurement := splitTopic[0], splitTopic[2]
+		tags := map[string]string{
+			"DeviceID": splitTopic[1],
+			"Phase":    splitTopic[5],
+		}
+		fields := map[string]interface{}{
+			splitTopic[6]: victronMessage.value,
+		}
+		victronInfluxMessage := InfluxMessage{
+			Measurement: measurement,
+			Tags:        tags,
+			Fields:      fields,
+			Time:        time.Now(),
+		}
+		writePoint(bucket, victronInfluxMessage, o.client, o.organization)
+
 	} else {
 		fmt.Printf("Unknown topic: %s", msg.Topic)
 		return

--- a/message_handler.go
+++ b/message_handler.go
@@ -191,7 +191,7 @@ func buildSolarPoints(payload []byte) (map[string]InfluxMessage, error) {
 func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, error) {
 	var victronMessage genericPayloadMessage
 	if err := json.Unmarshal(payload, &victronMessage); err != nil {
-		return "", InfluxMessage{}, err
+		return "", InfluxMessage{}, fmt.Errorf("topic %q: %w", topic, err)
 	}
 
 	splitTopic := strings.Split(topic, "/")
@@ -282,12 +282,14 @@ func (o *handler) handle(msg *paho.Publish) {
 
 		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
 	} else if strings.Contains(msg.Topic, "victron") {
-		bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
-		if err != nil {
-			fmt.Printf("Victron message could not be parsed (%s): %s", msg.Payload, err)
-			return
+		if !strings.HasSuffix(msg.Topic, "Batteries") {
+			bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
+			if err != nil {
+				fmt.Printf("Victron message could not be parsed (%s): %s", msg.Payload, err)
+				return
+			}
+			writePoint(bucket, victronInfluxMessage, o.client, o.organization)
 		}
-		writePoint(bucket, victronInfluxMessage, o.client, o.organization)
 
 	} else {
 		fmt.Printf("Unknown topic: %s", msg.Topic)

--- a/message_handler.go
+++ b/message_handler.go
@@ -200,6 +200,7 @@ func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, err
 	}
 
 	bucket := topicParts[0]
+	vrm_portal_id := topicParts[1]
 	serviceType := topicParts[2]
 	deviceInstance := ""
 	if len(topicParts) > 3 {
@@ -214,7 +215,7 @@ func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, err
 	point := InfluxMessage{
 		Measurement: serviceType,
 		Tags: map[string]string{
-			"vrm_portal_id":   splitTopic[1],
+			"vrm_portal_id":   vrm_portal_id,
 			"device_instance": deviceInstance,
 		},
 		Fields: map[string]interface{}{

--- a/message_handler.go
+++ b/message_handler.go
@@ -281,7 +281,7 @@ func (o *handler) handle(msg *paho.Publish) {
 		sensorInfluxMessage := toInfluxMessage(measurement, location, sensorId, sensorMessage)
 
 		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
-	} else if strings.Contains(msg.Topic, "victron") {
+	} else if strings.HasPrefix(msg.Topic, "victron/") {
 		if !strings.HasSuffix(msg.Topic, "Batteries") {
 			bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
 			if err != nil {

--- a/message_handler.go
+++ b/message_handler.go
@@ -194,21 +194,21 @@ func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, err
 		return "", InfluxMessage{}, fmt.Errorf("topic %q: %w", topic, err)
 	}
 
-	splitTopic := strings.Split(topic, "/")
-	if len(splitTopic) < 3 {
+	topicParts := strings.Split(topic, "/")
+	if len(topicParts) < 3 || topicParts[0] != "victron" {
 		return "", InfluxMessage{}, fmt.Errorf("topic is not in the correct format: %s", topic)
 	}
 
-	bucket := splitTopic[0]
-	serviceType := splitTopic[2]
+	bucket := topicParts[0]
+	serviceType := topicParts[2]
 	deviceInstance := ""
-	if len(splitTopic) > 3 {
-		deviceInstance = splitTopic[3]
+	if len(topicParts) > 3 {
+		deviceInstance = topicParts[3]
 	}
 
 	fieldKey := "value"
-	if len(splitTopic) > 4 {
-		fieldKey = strings.Join(splitTopic[4:], "/")
+	if len(topicParts) > 4 {
+		fieldKey = strings.Join(topicParts[4:], "/")
 	}
 
 	point := InfluxMessage{

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -94,11 +94,11 @@ func TestBuildVictronPoint_ExampleMessages(t *testing.T) {
 			if point.Measurement != tt.expectedMetric {
 				t.Errorf("expected measurement %q, got %q", tt.expectedMetric, point.Measurement)
 			}
-			if point.Tags["VRM_Portal_ID"] != tt.expectedPortal {
-				t.Errorf("expected VRM_Portal_ID %q, got %q", tt.expectedPortal, point.Tags["VRM_Portal_ID"])
+			if point.Tags["vrm_portal_id"] != tt.expectedPortal {
+				t.Errorf("expected vrm_portal_id %q, got %q", tt.expectedPortal, point.Tags["vrm_portal_id"])
 			}
-			if point.Tags["Device_Instance"] != tt.expectedDevice {
-				t.Errorf("expected Device_Instance %q, got %q", tt.expectedDevice, point.Tags["Device_Instance"])
+			if point.Tags["device_instance"] != tt.expectedDevice {
+				t.Errorf("expected device_instance %q, got %q", tt.expectedDevice, point.Tags["device_instance"])
 			}
 
 			gotValue, ok := point.Fields[tt.expectedField]

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/eclipse/paho.golang/paho"
+)
 
 func TestBuildVictronPoint_ExampleMessages(t *testing.T) {
 	tests := []struct {
@@ -50,6 +54,18 @@ func TestBuildVictronPoint_ExampleMessages(t *testing.T) {
 			expectedField:  "MaxDischargePower",
 			expectedValue:  4688.9998626709,
 			expectedMillis: 1782637544452,
+		},
+		{
+			name:           "four-part topic defaults field key to value",
+			topic:          "victron/a7f3c19de82b/hub4/0",
+			payload:        []byte(`{"value": 1250.5, "timestamp": 1782637540999}`),
+			expectedBucket: "victron",
+			expectedMetric: "hub4",
+			expectedPortal: "a7f3c19de82b",
+			expectedDevice: "0",
+			expectedField:  "value",
+			expectedValue:  1250.5,
+			expectedMillis: 1782637540999,
 		},
 		{
 			name:           "heartbeat message with short topic",
@@ -107,4 +123,36 @@ func TestBuildVictronPoint_InvalidInput(t *testing.T) {
 	if _, _, err := buildVictronPoint("victron/a/grid/1/x", []byte(`not-json`)); err == nil {
 		t.Fatal("expected error for invalid payload")
 	}
+}
+
+func TestHandle_SkipsVictronBatteriesTopic(t *testing.T) {
+	h := &handler{organization: "test-org", client: nil}
+	msg := &paho.Publish{
+		Topic: "victron/f29b4d80a6ce/system/0/Batteries",
+		Payload: []byte(`{
+			"value": [
+				{
+					"voltage": 50.09000015258789,
+					"temperature": 29.5,
+					"state": 1,
+					"soc": 53,
+					"power": 616,
+					"name": "Pylontech battery",
+					"instance": 512,
+					"id": "com.victronenergy.battery.socketcan_vecan1",
+					"current": 12.300000190734863,
+					"active_battery_service": true
+				}
+			],
+			"timestamp": 1782637542140
+		}`),
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("expected Batteries topic to be skipped without writing, but handle panicked: %v", r)
+		}
+	}()
+
+	h.handle(msg)
 }

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -40,6 +40,18 @@ func TestBuildVictronPoint_ExampleMessages(t *testing.T) {
 			expectedMillis: 1782637540383,
 		},
 		{
+			name:           "Max Discharge Power Message",
+			topic:          "victron/a7f3c19de82b/hub4/0/MaxDischargePower",
+			payload:        []byte(`{"value": 4688.9998626709, "timestamp": 1782637544452}`),
+			expectedBucket: "victron",
+			expectedMetric: "hub4",
+			expectedPortal: "a7f3c19de82b",
+			expectedDevice: "0",
+			expectedField:  "MaxDischargePower",
+			expectedValue:  4688.9998626709,
+			expectedMillis: 1782637544452,
+		},
+		{
 			name:           "heartbeat message with short topic",
 			topic:          "victron/a7f3c19de82b/heartbeat",
 			payload:        []byte(`{"value": 1782637540, "timestamp": 1782637540438}`),

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -1,0 +1,98 @@
+package main
+
+import "testing"
+
+func TestBuildVictronPoint_ExampleMessages(t *testing.T) {
+	tests := []struct {
+		name           string
+		topic          string
+		payload        []byte
+		expectedBucket string
+		expectedMetric string
+		expectedPortal string
+		expectedDevice string
+		expectedField  string
+		expectedValue  float64
+		expectedMillis int64
+	}{
+		{
+			name:           "grid power message",
+			topic:          "victron/a7f3c19de82b/grid/40/Ac/L3/Power",
+			payload:        []byte(`{"value": -1393, "timestamp": 1782637540236}`),
+			expectedBucket: "victron",
+			expectedMetric: "grid",
+			expectedPortal: "a7f3c19de82b",
+			expectedDevice: "40",
+			expectedField:  "Ac/L3/Power",
+			expectedValue:  -1393,
+			expectedMillis: 1782637540236,
+		},
+		{
+			name:           "system pv output power message",
+			topic:          "victron/f29b4d80a6ce/system/0/Ac/PvOnOutput/L1/Power",
+			payload:        []byte(`{"value": 1527.6, "timestamp": 1782637540383}`),
+			expectedBucket: "victron",
+			expectedMetric: "system",
+			expectedPortal: "f29b4d80a6ce",
+			expectedDevice: "0",
+			expectedField:  "Ac/PvOnOutput/L1/Power",
+			expectedValue:  1527.6,
+			expectedMillis: 1782637540383,
+		},
+		{
+			name:           "heartbeat message with short topic",
+			topic:          "victron/a7f3c19de82b/heartbeat",
+			payload:        []byte(`{"value": 1782637540, "timestamp": 1782637540438}`),
+			expectedBucket: "victron",
+			expectedMetric: "heartbeat",
+			expectedPortal: "a7f3c19de82b",
+			expectedDevice: "",
+			expectedField:  "value",
+			expectedValue:  1782637540,
+			expectedMillis: 1782637540438,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bucket, point, err := buildVictronPoint(tt.topic, tt.payload)
+			if err != nil {
+				t.Fatalf("buildVictronPoint returned error: %v", err)
+			}
+
+			if bucket != tt.expectedBucket {
+				t.Errorf("expected bucket %q, got %q", tt.expectedBucket, bucket)
+			}
+			if point.Measurement != tt.expectedMetric {
+				t.Errorf("expected measurement %q, got %q", tt.expectedMetric, point.Measurement)
+			}
+			if point.Tags["VRM_Portal_ID"] != tt.expectedPortal {
+				t.Errorf("expected VRM_Portal_ID %q, got %q", tt.expectedPortal, point.Tags["VRM_Portal_ID"])
+			}
+			if point.Tags["Device_Instance"] != tt.expectedDevice {
+				t.Errorf("expected Device_Instance %q, got %q", tt.expectedDevice, point.Tags["Device_Instance"])
+			}
+
+			gotValue, ok := point.Fields[tt.expectedField]
+			if !ok {
+				t.Fatalf("expected field key %q to exist", tt.expectedField)
+			}
+			if gotValue != tt.expectedValue {
+				t.Errorf("expected field value %v, got %v", tt.expectedValue, gotValue)
+			}
+			if point.Time.UnixMilli() != tt.expectedMillis {
+				t.Errorf("expected timestamp %d, got %d", tt.expectedMillis, point.Time.UnixMilli())
+			}
+		})
+	}
+}
+
+func TestBuildVictronPoint_InvalidInput(t *testing.T) {
+	if _, _, err := buildVictronPoint("victron/too-short", []byte(`{"value": 1, "timestamp": 2}`)); err == nil {
+		t.Fatal("expected error for malformed topic")
+	}
+
+	if _, _, err := buildVictronPoint("victron/a/grid/1/x", []byte(`not-json`)); err == nil {
+		t.Fatal("expected error for invalid payload")
+	}
+}


### PR DESCRIPTION
This pull request adds support for parsing and handling Victron device messages in the MQTT message handler, including robust topic parsing, error handling, and comprehensive unit tests. It introduces a generic payload structure for Victron messages, a new function to process these messages, and updates the main handler logic to support the new message type while skipping unsupported topics.

**Victron message support:**

* Added a new `genericPayloadMessage` struct to represent generic Victron payloads with `value` and `timestamp` fields.
* Implemented the `buildVictronPoint` function to parse Victron MQTT topics and payloads, extract relevant fields, and construct an `InfluxMessage` for storage. This includes robust error handling for malformed topics and payloads.
* Updated the main handler logic in the `handle` method to process Victron messages (except those ending with `Batteries`), parse them using `buildVictronPoint`, and write the resulting point to InfluxDB.

**Testing and validation:**

* Added a comprehensive test suite in `message_handler_test.go` to validate `buildVictronPoint` with various topic formats, check error handling for invalid input, and ensure that `Batteries` topics are correctly skipped.