### PR TITLE
feat: Support for InfluxDB batching with writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ The application is configured using environment variables. Below are the key var
 | `INFLUXDB_ORG`         | Organization name in InfluxDB       | `your-org`               |
 | `INFLUXDB_BUCKET`      | Bucket name in InfluxDB             | `your-bucket`            |
 
+### Influx Write Tuning (Optional)
+
+These variables control client-side async batching. If unset, defaults are used.
+
+| Variable                        | Default | Description |
+|---------------------------------|---------|-------------|
+| `INFLUXDB_WRITE_BATCH_SIZE`     | `5000`  | Maximum points queued before an automatic flush |
+| `INFLUXDB_FLUSH_INTERVAL_MS`    | `1000`  | Periodic flush interval in milliseconds |
+
 ## Running the Application
 1. Set the required environment variables.
 2. Run the application:

--- a/README.md
+++ b/README.md
@@ -30,16 +30,22 @@ This project is a Go-based application that acts as a bridge between an MQTT bro
 ## Configuration
 The application is configured using environment variables. Below are the key variables:
 
-| Variable               | Description                          | Example Value            |
-|------------------------|--------------------------------------|--------------------------|
-| `MQTT_SERVER_URL`      | URL of the MQTT broker              | `tcp://localhost:1883`   |
-| `MQTT_CLIENT_ID`       | Client ID for the MQTT connection   | `mqtt-client`            |
-| `MQTT_TOPIC`           | Topic to subscribe to               | `sensors/temperature`    |
-| `MQTT_QOS`             | Quality of Service level            | `1`                      |
-| `INFLUXDB_URL`         | URL of the InfluxDB instance        | `http://localhost:8086`  |
-| `INFLUXDB_TOKEN`       | Authentication token for InfluxDB   | `your-token`             |
-| `INFLUXDB_ORG`         | Organization name in InfluxDB       | `your-org`               |
-| `INFLUXDB_BUCKET`      | Bucket name in InfluxDB             | `your-bucket`            |
+| Variable | Required | Description | Example Value |
+|----------|----------|-------------|---------------|
+| `MQTTBROKERURL` | Yes | MQTT broker URL | `tcp://localhost:1883` |
+| `CLIENTID` | Yes | MQTT client ID | `mqtt-influxdb-bridge` |
+| `TOPIC` | Yes | MQTT topic to subscribe to | `sensors/temperature` |
+| `QOS` | Yes | MQTT QoS (`0`, `1`, or `2`) | `1` |
+| `CAFILE` | Yes | Path to CA certificate file | `/certs/ca.crt` |
+| `CERTFILE` | Yes | Path to client certificate file | `/certs/client.crt` |
+| `KEYFILE` | Yes | Path to client private key file | `/certs/client.key` |
+| `KEEPALIVE` | Yes | MQTT keepalive interval in seconds | `30` |
+| `RETRYINTERVAL` | Yes | Reconnect retry interval in milliseconds | `5000` |
+| `INFLUXDB_URL` | Yes | InfluxDB server URL | `http://localhost:8086` |
+| `INFLUXDB_TOKEN` | Yes | InfluxDB authentication token | `your-token` |
+| `INFLUXDB_ORG` | Yes | InfluxDB organization | `your-org` |
+| `SESSIONFOLDER` | No | Folder used to persist MQTT session state (empty uses in-memory state) | `/data/session` |
+| `DEBUG` | No | Enable Paho/autopaho debug logging (`true`/`false`) | `false` |
 
 ### Influx Write Tuning (Optional)
 

--- a/config.go
+++ b/config.go
@@ -32,8 +32,8 @@ const (
 	envSessionFolder = "SESSIONFOLDER" // folder used to persist the session state (if empty state will be held in RAM)
 	envDebug         = "DEBUG"         // if "true" then the libraries will be instructed to print debug info
 
-	envInfluxWriteBatchSize  = "INFLUXDB_WRITE_BATCH_SIZE"  // max points per write batch
-	envInfluxFlushInterval = "INFLUXDB_FLUSH_INTERVAL_MS" // periodic flush interval in milliseconds
+	envInfluxWriteBatchSize = "INFLUXDB_WRITE_BATCH_SIZE"  // max points per write batch
+	envInfluxFlushInterval  = "INFLUXDB_FLUSH_INTERVAL_MS" // periodic flush interval in milliseconds
 )
 
 // config holds the configuration
@@ -56,8 +56,8 @@ type config struct {
 	influxToken string // token to use when connecting to influx
 	influxOrg   string // organization to use when connecting to influx
 
-	influxWriteBatchSize  uint          // max points in a single async write batch
-	influxFlushIntervalMS time.Duration // async write flush interval
+	influxWriteBatchSize uint          // max points in a single async write batch
+	influxFlushInterval  time.Duration // async write flush interval
 
 	debug bool // autopaho and paho debug output requested
 }
@@ -134,7 +134,7 @@ func getConfig() (config, error) {
 	}
 	cfg.influxWriteBatchSize = uint(batchSize)
 
-	cfg.influxFlushIntervalMS, err = milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
+	cfg.influxFlushInterval, err = milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
 	if err != nil {
 		return config{}, err
 	}

--- a/config.go
+++ b/config.go
@@ -31,6 +31,9 @@ const (
 
 	envSessionFolder = "SESSIONFOLDER" // folder used to persist the session state (if empty state will be held in RAM)
 	envDebug         = "DEBUG"         // if "true" then the libraries will be instructed to print debug info
+
+	envInfluxWriteBatchSize  = "INFLUXDB_WRITE_BATCH_SIZE"  // max points per write batch
+	envInfluxFlushIntervalMS = "INFLUXDB_FLUSH_INTERVAL_MS" // periodic flush interval in milliseconds
 )
 
 // config holds the configuration
@@ -52,6 +55,9 @@ type config struct {
 	influxURL   string // URL of the influx server
 	influxToken string // token to use when connecting to influx
 	influxOrg   string // organization to use when connecting to influx
+
+	influxWriteBatchSize  uint          // max points in a single async write batch
+	influxFlushIntervalMS time.Duration // async write flush interval
 
 	debug bool // autopaho and paho debug output requested
 }
@@ -122,6 +128,17 @@ func getConfig() (config, error) {
 		return config{}, err
 	}
 
+	batchSize, err := intFromEnvWithDefault(envInfluxWriteBatchSize, 5000, 32)
+	if err != nil {
+		return config{}, err
+	}
+	cfg.influxWriteBatchSize = uint(batchSize)
+
+	cfg.influxFlushIntervalMS, err = milliSecondsFromEnvWithDefault(envInfluxFlushIntervalMS, 1000)
+	if err != nil {
+		return config{}, err
+	}
+
 	return cfg, nil
 }
 
@@ -147,11 +164,35 @@ func intFromEnv(key string, maxsize int) (uint64, error) {
 	return i, nil
 }
 
+func intFromEnvWithDefault(key string, defaultValue uint64, maxsize int) (uint64, error) {
+	s := os.Getenv(key)
+	if len(s) == 0 {
+		return defaultValue, nil
+	}
+	i, err := strconv.ParseUint(s, 10, maxsize)
+	if err != nil {
+		return 0, fmt.Errorf("environmental variable %s must be an integer", key)
+	}
+	return i, nil
+}
+
 // milliSecondsFromEnv - Retrieves milliseconds (as time.Duration) from the environment (must be present and valid)
 func milliSecondsFromEnv(key string) (time.Duration, error) {
 	s := os.Getenv(key)
 	if len(s) == 0 {
 		return 0, fmt.Errorf("environmental variable %s must not be blank", key)
+	}
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("environmental variable %s must be an integer", key)
+	}
+	return time.Duration(i) * time.Millisecond, nil
+}
+
+func milliSecondsFromEnvWithDefault(key string, defaultValueMS int) (time.Duration, error) {
+	s := os.Getenv(key)
+	if len(s) == 0 {
+		return time.Duration(defaultValueMS) * time.Millisecond, nil
 	}
 	i, err := strconv.Atoi(s)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ const (
 	envDebug         = "DEBUG"         // if "true" then the libraries will be instructed to print debug info
 
 	envInfluxWriteBatchSize  = "INFLUXDB_WRITE_BATCH_SIZE"  // max points per write batch
-	envInfluxFlushIntervalMS = "INFLUXDB_FLUSH_INTERVAL_MS" // periodic flush interval in milliseconds
+	envInfluxFlushInterval = "INFLUXDB_FLUSH_INTERVAL_MS" // periodic flush interval in milliseconds
 )
 
 // config holds the configuration
@@ -134,7 +134,7 @@ func getConfig() (config, error) {
 	}
 	cfg.influxWriteBatchSize = uint(batchSize)
 
-	cfg.influxFlushIntervalMS, err = milliSecondsFromEnvWithDefault(envInfluxFlushIntervalMS, 1000)
+	cfg.influxFlushIntervalMS, err = milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
 	if err != nil {
 		return config{}, err
 	}

--- a/config.go
+++ b/config.go
@@ -132,6 +132,9 @@ func getConfig() (config, error) {
 	if err != nil {
 		return config{}, err
 	}
+	if batchSize == 0 {
+		return config{}, fmt.Errorf("environmental variable %s must be a positive integer", envInfluxWriteBatchSize)
+	}
 	cfg.influxWriteBatchSize = uint(batchSize)
 
 	cfg.influxFlushInterval, err = milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
@@ -197,6 +200,9 @@ func milliSecondsFromEnvWithDefault(key string, defaultValueMS int) (time.Durati
 	i, err := strconv.Atoi(s)
 	if err != nil {
 		return 0, fmt.Errorf("environmental variable %s must be an integer", key)
+	}
+	if i <= 0 {
+		return 0, fmt.Errorf("environmental variable %s must be a positive integer", key)
 	}
 	return time.Duration(i) * time.Millisecond, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -189,3 +189,145 @@ func TestIntFromEnvNegative(t *testing.T) {
 		t.Fatal("expected error for negative integer")
 	}
 }
+
+func TestInfluxWriteBatchSizeDefault(t *testing.T) {
+	setEnv(envServerURL, "http://localhost:1883")
+	setEnv(envClientID, "testClient")
+	setEnv(envTopic, "test/topic")
+	setEnv(envQos, "1")
+	setEnv(caFile, "path/to/ca.pem")
+	setEnv(clientFile, "path/to/client.pem")
+	setEnv(keyFile, "path/to/key.pem")
+	setEnv(envKeepAlive, "60")
+	setEnv(envConnectRetryDelay, "1000")
+	setEnv(influxURL, "http://localhost:8086")
+	setEnv(influxToken, "testToken")
+	setEnv(influxOrg, "testOrg")
+	defer func() {
+		unsetEnv(envServerURL)
+		unsetEnv(envClientID)
+		unsetEnv(envTopic)
+		unsetEnv(envQos)
+		unsetEnv(caFile)
+		unsetEnv(clientFile)
+		unsetEnv(keyFile)
+		unsetEnv(envKeepAlive)
+		unsetEnv(envConnectRetryDelay)
+		unsetEnv(influxURL)
+		unsetEnv(influxToken)
+		unsetEnv(influxOrg)
+		unsetEnv(envInfluxWriteBatchSize)
+		unsetEnv(envInfluxFlushInterval)
+	}()
+
+	cfg, err := getConfig()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cfg.influxWriteBatchSize != 5000 {
+		t.Errorf("expected default influxWriteBatchSize 5000, got %d", cfg.influxWriteBatchSize)
+	}
+	if cfg.influxFlushInterval != 1000*time.Millisecond {
+		t.Errorf("expected default influxFlushInterval 1000ms, got %v", cfg.influxFlushInterval)
+	}
+}
+
+func TestInfluxWriteBatchSizeZeroRejected(t *testing.T) {
+	setEnv(envInfluxWriteBatchSize, "0")
+	defer unsetEnv(envInfluxWriteBatchSize)
+
+	_, err := intFromEnvWithDefault(envInfluxWriteBatchSize, 5000, 32)
+	if err != nil {
+		t.Fatalf("intFromEnvWithDefault returned unexpected error: %v", err)
+	}
+	// Validate that getConfig rejects a zero batch size end-to-end
+	setEnv(envServerURL, "http://localhost:1883")
+	setEnv(envClientID, "testClient")
+	setEnv(envTopic, "test/topic")
+	setEnv(envQos, "1")
+	setEnv(caFile, "path/to/ca.pem")
+	setEnv(clientFile, "path/to/client.pem")
+	setEnv(keyFile, "path/to/key.pem")
+	setEnv(envKeepAlive, "60")
+	setEnv(envConnectRetryDelay, "1000")
+	setEnv(influxURL, "http://localhost:8086")
+	setEnv(influxToken, "testToken")
+	setEnv(influxOrg, "testOrg")
+	defer func() {
+		unsetEnv(envServerURL)
+		unsetEnv(envClientID)
+		unsetEnv(envTopic)
+		unsetEnv(envQos)
+		unsetEnv(caFile)
+		unsetEnv(clientFile)
+		unsetEnv(keyFile)
+		unsetEnv(envKeepAlive)
+		unsetEnv(envConnectRetryDelay)
+		unsetEnv(influxURL)
+		unsetEnv(influxToken)
+		unsetEnv(influxOrg)
+	}()
+
+	_, err = getConfig()
+	if err == nil {
+		t.Fatal("expected error when INFLUXDB_WRITE_BATCH_SIZE=0, got nil")
+	}
+}
+
+func TestInfluxWriteBatchSizeInvalidRejected(t *testing.T) {
+	_, err := intFromEnvWithDefault(envInfluxWriteBatchSize, 5000, 32)
+	if err != nil {
+		t.Fatalf("unexpected error with missing env var: %v", err)
+	}
+
+	setEnv(envInfluxWriteBatchSize, "not-a-number")
+	defer unsetEnv(envInfluxWriteBatchSize)
+
+	_, err = intFromEnvWithDefault(envInfluxWriteBatchSize, 5000, 32)
+	if err == nil {
+		t.Fatal("expected error for non-integer INFLUXDB_WRITE_BATCH_SIZE")
+	}
+}
+
+func TestInfluxFlushIntervalZeroRejected(t *testing.T) {
+	setEnv(envInfluxFlushInterval, "0")
+	defer unsetEnv(envInfluxFlushInterval)
+
+	_, err := milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
+	if err == nil {
+		t.Fatal("expected error when INFLUXDB_FLUSH_INTERVAL_MS=0")
+	}
+}
+
+func TestInfluxFlushIntervalNegativeRejected(t *testing.T) {
+	setEnv(envInfluxFlushInterval, "-500")
+	defer unsetEnv(envInfluxFlushInterval)
+
+	_, err := milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
+	if err == nil {
+		t.Fatal("expected error when INFLUXDB_FLUSH_INTERVAL_MS is negative")
+	}
+}
+
+func TestInfluxFlushIntervalInvalidRejected(t *testing.T) {
+	setEnv(envInfluxFlushInterval, "not-a-number")
+	defer unsetEnv(envInfluxFlushInterval)
+
+	_, err := milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
+	if err == nil {
+		t.Fatal("expected error for non-integer INFLUXDB_FLUSH_INTERVAL_MS")
+	}
+}
+
+func TestInfluxFlushIntervalCustomValue(t *testing.T) {
+	setEnv(envInfluxFlushInterval, "2500")
+	defer unsetEnv(envInfluxFlushInterval)
+
+	d, err := milliSecondsFromEnvWithDefault(envInfluxFlushInterval, 1000)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if d != 2500*time.Millisecond {
+		t.Errorf("expected 2500ms, got %v", d)
+	}
+}

--- a/influxdb.go
+++ b/influxdb.go
@@ -27,7 +27,7 @@ func influxClient(cfg config) influxdb2.Client {
 	clientOptions.SetApplicationName("p1DataWriterGo")
 	clientOptions.SetTLSConfig(creatTLSConfigInflux())
 	clientOptions.SetBatchSize(cfg.influxWriteBatchSize)
-	clientOptions.SetFlushInterval(uint(cfg.influxFlushIntervalMS.Milliseconds()))
+	clientOptions.SetFlushInterval(uint(cfg.influxFlushInterval.Milliseconds()))
 
 	client := influxdb2.NewClientWithOptions(cfg.influxURL, cfg.influxToken, clientOptions)
 	return client

--- a/influxdb.go
+++ b/influxdb.go
@@ -26,14 +26,9 @@ func influxClient(cfg config) influxdb2.Client {
 
 	clientOptions.SetApplicationName("p1DataWriterGo")
 	clientOptions.SetTLSConfig(creatTLSConfigInflux())
+	clientOptions.SetBatchSize(cfg.influxWriteBatchSize)
+	clientOptions.SetFlushInterval(uint(cfg.influxFlushIntervalMS.Milliseconds()))
 
 	client := influxdb2.NewClientWithOptions(cfg.influxURL, cfg.influxToken, clientOptions)
 	return client
-}
-
-func writePoint(topic string, payload InfluxMessage, client influxdb2.Client, organization string) {
-	writeAPI := client.WriteAPI(organization, topic)
-	p := influxdb2.NewPoint(payload.Measurement, payload.Tags, payload.Fields, payload.Time)
-	writeAPI.WritePoint(p)
-	writeAPI.Flush()
 }

--- a/message_handler.go
+++ b/message_handler.go
@@ -43,6 +43,11 @@ func splitTopic(topic string) (string, string, error) {
 	return mainTopic, subTopic, nil
 }
 
+type genericPayloadMessage struct {
+	value float64   `json:"value"`
+	time  time.Time `json:"time"`
+}
+
 type sensorMessage struct {
 	Unit      string    `json:"unit"`
 	Value     float64   `json:"value"`
@@ -238,6 +243,33 @@ func (o *handler) handle(msg *paho.Publish) {
 		sensorInfluxMessage := toInfluxMessage(measurement, location, sensorId, sensorMessage)
 
 		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
+	} else if strings.Contains(msg.Topic, "victron") {
+		var victronMessage genericPayloadMessage
+		err := json.Unmarshal(msg.Payload, &victronMessage)
+		if err != nil {
+			fmt.Printf("Message could not be parsed (%s): %s", msg.Payload, err)
+		}
+		splitTopic := strings.Split(msg.Topic, "/")
+		if len(splitTopic) < 7 {
+			fmt.Printf("Topic is not in the correct format: %s", msg.Topic)
+			return
+		}
+		bucket, measurement := splitTopic[0], splitTopic[2]
+		tags := map[string]string{
+			"DeviceID": splitTopic[1],
+			"Phase":    splitTopic[5],
+		}
+		fields := map[string]interface{}{
+			splitTopic[6]: victronMessage.value,
+		}
+		victronInfluxMessage := InfluxMessage{
+			Measurement: measurement,
+			Tags:        tags,
+			Fields:      fields,
+			Time:        time.Now(),
+		}
+		writePoint(bucket, victronInfluxMessage, o.client, o.organization)
+
 	} else {
 		fmt.Printf("Unknown topic: %s", msg.Topic)
 		return

--- a/message_handler.go
+++ b/message_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eclipse/paho.golang/paho"
@@ -16,6 +17,8 @@ import (
 type handler struct {
 	organization string
 	client       influxdb2.Client
+	writeAPIs    map[string]api.WriteAPI
+	mu           sync.Mutex
 }
 
 // NewHandler creates a new output handler and opens the output file (if applicable)
@@ -24,12 +27,45 @@ func NewHandler(cfg config) *handler {
 	return &handler{
 		organization: cfg.influxOrg,
 		client:       influxClient(cfg),
+		writeAPIs:    make(map[string]api.WriteAPI),
 	}
 }
 
 // Close closes the influxDB client
 func (o *handler) Close() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for _, writeAPI := range o.writeAPIs {
+		writeAPI.Flush()
+	}
 	o.client.Close()
+}
+
+func (o *handler) getWriteAPI(bucket string) api.WriteAPI {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if writeAPI, ok := o.writeAPIs[bucket]; ok {
+		return writeAPI
+	}
+
+	writeAPI := o.client.WriteAPI(o.organization, bucket)
+	o.writeAPIs[bucket] = writeAPI
+
+	go func(targetBucket string, errs <-chan error) {
+		for err := range errs {
+			fmt.Printf("Influx write error in bucket %q: %v\n", targetBucket, err)
+		}
+	}(bucket, writeAPI.Errors())
+
+	return writeAPI
+}
+
+func (o *handler) writePoint(bucket string, payload InfluxMessage) {
+	writeAPI := o.getWriteAPI(bucket)
+	p := influxdb2.NewPoint(payload.Measurement, payload.Tags, payload.Fields, payload.Time)
+	writeAPI.WritePoint(p)
 }
 
 func splitTopic(topic string) (string, string, error) {
@@ -44,8 +80,8 @@ func splitTopic(topic string) (string, string, error) {
 }
 
 type genericPayloadMessage struct {
-	value float64   `json:"value"`
-	time  time.Time `json:"time"`
+	Value     float64 `json:"value"`
+	Timestamp float64 `json:"timestamp"`
 }
 
 type sensorMessage struct {
@@ -195,22 +231,67 @@ func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization
 		return
 	}
 
-	writeAPIs := make(map[string]api.WriteAPI)
 	for bucket, influxMsg := range points {
 		writeAPI := client.WriteAPI(organization, bucket)
-		writeAPIs[bucket] = writeAPI
 		p := influxdb2.NewPoint(influxMsg.Measurement, influxMsg.Tags, influxMsg.Fields, influxMsg.Time)
 		writeAPI.WritePoint(p)
 	}
-	for _, writeAPI := range writeAPIs {
-		writeAPI.Flush()
+}
+
+func (o *handler) handleSolarMessage(msg *paho.Publish) {
+	points, err := buildSolarPoints(msg.Payload)
+	if err != nil {
+		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
+		return
 	}
+
+	for bucket, influxMsg := range points {
+		o.writePoint(bucket, influxMsg)
+	}
+}
+
+func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, error) {
+	var victronMessage genericPayloadMessage
+	if err := json.Unmarshal(payload, &victronMessage); err != nil {
+		return "", InfluxMessage{}, err
+	}
+
+	splitTopic := strings.Split(topic, "/")
+	if len(splitTopic) < 3 {
+		return "", InfluxMessage{}, fmt.Errorf("topic is not in the correct format: %s", topic)
+	}
+
+	bucket := splitTopic[0]
+	serviceType := splitTopic[2]
+	deviceInstance := ""
+	if len(splitTopic) > 3 {
+		deviceInstance = splitTopic[3]
+	}
+
+	fieldKey := "value"
+	if len(splitTopic) > 4 {
+		fieldKey = strings.Join(splitTopic[4:], "/")
+	}
+
+	point := InfluxMessage{
+		Measurement: serviceType,
+		Tags: map[string]string{
+			"VRM_Portal_ID":   splitTopic[1],
+			"Device_Instance": deviceInstance,
+		},
+		Fields: map[string]interface{}{
+			fieldKey: victronMessage.Value,
+		},
+		Time: time.UnixMilli(int64(victronMessage.Timestamp)),
+	}
+
+	return bucket, point, nil
 }
 
 // handle is called when a message is received
 func (o *handler) handle(msg *paho.Publish) {
 	if strings.HasPrefix(msg.Topic, "solaredge/") {
-		handleSolarMessage(msg, o.client, o.organization)
+		o.handleSolarMessage(msg)
 	} else if strings.Contains(msg.Topic, "p1") {
 		var p1Message InfluxMessage
 		err := json.Unmarshal(msg.Payload, &p1Message)
@@ -222,7 +303,7 @@ func (o *handler) handle(msg *paho.Publish) {
 			fmt.Printf("Error splitting topic: %s", err)
 			return
 		}
-		writePoint(subTopic, p1Message, o.client, o.organization)
+		o.writePoint(subTopic, p1Message)
 	} else if strings.Contains(msg.Topic, "sensors") {
 		var sensorMessage sensorMessage
 		err := json.Unmarshal(msg.Payload, &sensorMessage)
@@ -242,33 +323,14 @@ func (o *handler) handle(msg *paho.Publish) {
 
 		sensorInfluxMessage := toInfluxMessage(measurement, location, sensorId, sensorMessage)
 
-		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
+		o.writePoint(bucket, sensorInfluxMessage)
 	} else if strings.Contains(msg.Topic, "victron") {
-		var victronMessage genericPayloadMessage
-		err := json.Unmarshal(msg.Payload, &victronMessage)
+		bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
 		if err != nil {
 			fmt.Printf("Message could not be parsed (%s): %s", msg.Payload, err)
-		}
-		splitTopic := strings.Split(msg.Topic, "/")
-		if len(splitTopic) < 7 {
-			fmt.Printf("Topic is not in the correct format: %s", msg.Topic)
 			return
 		}
-		bucket, measurement := splitTopic[0], splitTopic[2]
-		tags := map[string]string{
-			"DeviceID": splitTopic[1],
-			"Phase":    splitTopic[5],
-		}
-		fields := map[string]interface{}{
-			splitTopic[6]: victronMessage.value,
-		}
-		victronInfluxMessage := InfluxMessage{
-			Measurement: measurement,
-			Tags:        tags,
-			Fields:      fields,
-			Time:        time.Now(),
-		}
-		writePoint(bucket, victronInfluxMessage, o.client, o.organization)
+		o.writePoint(bucket, victronInfluxMessage)
 
 	} else {
 		fmt.Printf("Unknown topic: %s", msg.Topic)

--- a/message_handler.go
+++ b/message_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/eclipse/paho.golang/paho"
@@ -16,6 +17,8 @@ import (
 type handler struct {
 	organization string
 	client       influxdb2.Client
+	writeAPIs    map[string]api.WriteAPI
+	mu           sync.Mutex
 }
 
 // NewHandler creates a new output handler and opens the output file (if applicable)
@@ -24,12 +27,45 @@ func NewHandler(cfg config) *handler {
 	return &handler{
 		organization: cfg.influxOrg,
 		client:       influxClient(cfg),
+		writeAPIs:    make(map[string]api.WriteAPI),
 	}
 }
 
 // Close closes the influxDB client
 func (o *handler) Close() {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	for _, writeAPI := range o.writeAPIs {
+		writeAPI.Flush()
+	}
 	o.client.Close()
+}
+
+func (o *handler) getWriteAPI(bucket string) api.WriteAPI {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if writeAPI, ok := o.writeAPIs[bucket]; ok {
+		return writeAPI
+	}
+
+	writeAPI := o.client.WriteAPI(o.organization, bucket)
+	o.writeAPIs[bucket] = writeAPI
+
+	go func(targetBucket string, errs <-chan error) {
+		for err := range errs {
+			fmt.Printf("Influx write error in bucket %q: %v\n", targetBucket, err)
+		}
+	}(bucket, writeAPI.Errors())
+
+	return writeAPI
+}
+
+func (o *handler) writePoint(bucket string, payload InfluxMessage) {
+	writeAPI := o.getWriteAPI(bucket)
+	p := influxdb2.NewPoint(payload.Measurement, payload.Tags, payload.Fields, payload.Time)
+	writeAPI.WritePoint(p)
 }
 
 func splitTopic(topic string) (string, string, error) {
@@ -234,22 +270,67 @@ func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization
 		return
 	}
 
-	writeAPIs := make(map[string]api.WriteAPI)
 	for bucket, influxMsg := range points {
 		writeAPI := client.WriteAPI(organization, bucket)
-		writeAPIs[bucket] = writeAPI
 		p := influxdb2.NewPoint(influxMsg.Measurement, influxMsg.Tags, influxMsg.Fields, influxMsg.Time)
 		writeAPI.WritePoint(p)
 	}
-	for _, writeAPI := range writeAPIs {
-		writeAPI.Flush()
+}
+
+func (o *handler) handleSolarMessage(msg *paho.Publish) {
+	points, err := buildSolarPoints(msg.Payload)
+	if err != nil {
+		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
+		return
 	}
+
+	for bucket, influxMsg := range points {
+		o.writePoint(bucket, influxMsg)
+	}
+}
+
+func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, error) {
+	var victronMessage genericPayloadMessage
+	if err := json.Unmarshal(payload, &victronMessage); err != nil {
+		return "", InfluxMessage{}, err
+	}
+
+	splitTopic := strings.Split(topic, "/")
+	if len(splitTopic) < 3 {
+		return "", InfluxMessage{}, fmt.Errorf("topic is not in the correct format: %s", topic)
+	}
+
+	bucket := splitTopic[0]
+	serviceType := splitTopic[2]
+	deviceInstance := ""
+	if len(splitTopic) > 3 {
+		deviceInstance = splitTopic[3]
+	}
+
+	fieldKey := "value"
+	if len(splitTopic) > 4 {
+		fieldKey = strings.Join(splitTopic[4:], "/")
+	}
+
+	point := InfluxMessage{
+		Measurement: serviceType,
+		Tags: map[string]string{
+			"VRM_Portal_ID":   splitTopic[1],
+			"Device_Instance": deviceInstance,
+		},
+		Fields: map[string]interface{}{
+			fieldKey: victronMessage.Value,
+		},
+		Time: time.UnixMilli(int64(victronMessage.Timestamp)),
+	}
+
+	return bucket, point, nil
 }
 
 // handle is called when a message is received
 func (o *handler) handle(msg *paho.Publish) {
 	if strings.HasPrefix(msg.Topic, "solaredge/") {
-		handleSolarMessage(msg, o.client, o.organization)
+		o.handleSolarMessage(msg)
 	} else if strings.Contains(msg.Topic, "p1") {
 		var p1Message InfluxMessage
 		err := json.Unmarshal(msg.Payload, &p1Message)
@@ -261,7 +342,7 @@ func (o *handler) handle(msg *paho.Publish) {
 			fmt.Printf("Error splitting topic: %s", err)
 			return
 		}
-		writePoint(subTopic, p1Message, o.client, o.organization)
+		o.writePoint(subTopic, p1Message)
 	} else if strings.Contains(msg.Topic, "sensors") {
 		var sensorMessage sensorMessage
 		err := json.Unmarshal(msg.Payload, &sensorMessage)

--- a/message_handler.go
+++ b/message_handler.go
@@ -43,9 +43,6 @@ func (o *handler) Close() {
 }
 
 func (o *handler) getWriteAPI(bucket string) api.WriteAPI {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-
 	if writeAPI, ok := o.writeAPIs[bucket]; ok {
 		return writeAPI
 	}
@@ -63,6 +60,9 @@ func (o *handler) getWriteAPI(bucket string) api.WriteAPI {
 }
 
 func (o *handler) writePoint(bucket string, payload InfluxMessage) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
 	writeAPI := o.getWriteAPI(bucket)
 	p := influxdb2.NewPoint(payload.Measurement, payload.Tags, payload.Fields, payload.Time)
 	writeAPI.WritePoint(p)

--- a/message_handler.go
+++ b/message_handler.go
@@ -326,7 +326,7 @@ func (o *handler) handle(msg *paho.Publish) {
 
 		o.writePoint(bucket, sensorInfluxMessage)
 	} else if strings.HasPrefix(msg.Topic, "victron/") {
-		if !strings.HasSuffix(msg.Topic, "Batteries") {
+		if !strings.HasSuffix(msg.Topic, "Batteries") && !strings.HasSuffix(msg.Topic, "Network/Services") {
 			bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
 			if err != nil {
 				fmt.Printf("Victron message could not be parsed (%s): %s", msg.Payload, err)

--- a/message_handler.go
+++ b/message_handler.go
@@ -224,6 +224,32 @@ func buildSolarPoints(payload []byte) (map[string]InfluxMessage, error) {
 	return result, nil
 }
 
+func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization string) {
+	points, err := buildSolarPoints(msg.Payload)
+	if err != nil {
+		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
+		return
+	}
+
+	for bucket, influxMsg := range points {
+		writeAPI := client.WriteAPI(organization, bucket)
+		p := influxdb2.NewPoint(influxMsg.Measurement, influxMsg.Tags, influxMsg.Fields, influxMsg.Time)
+		writeAPI.WritePoint(p)
+	}
+}
+
+func (o *handler) handleSolarMessage(msg *paho.Publish) {
+	points, err := buildSolarPoints(msg.Payload)
+	if err != nil {
+		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
+		return
+	}
+
+	for bucket, influxMsg := range points {
+		o.writePoint(bucket, influxMsg)
+	}
+}
+
 func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, error) {
 	var victronMessage genericPayloadMessage
 	if err := json.Unmarshal(payload, &victronMessage); err != nil {
@@ -258,70 +284,6 @@ func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, err
 			fieldKey: victronMessage.Value,
 		},
 		Time: time.UnixMilli(victronMessage.Timestamp),
-	}
-
-	return bucket, point, nil
-}
-
-func handleSolarMessage(msg *paho.Publish, client influxdb2.Client, organization string) {
-	points, err := buildSolarPoints(msg.Payload)
-	if err != nil {
-		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
-		return
-	}
-
-	for bucket, influxMsg := range points {
-		writeAPI := client.WriteAPI(organization, bucket)
-		p := influxdb2.NewPoint(influxMsg.Measurement, influxMsg.Tags, influxMsg.Fields, influxMsg.Time)
-		writeAPI.WritePoint(p)
-	}
-}
-
-func (o *handler) handleSolarMessage(msg *paho.Publish) {
-	points, err := buildSolarPoints(msg.Payload)
-	if err != nil {
-		fmt.Printf("Solar message could not be parsed (%s): %s", msg.Payload, err)
-		return
-	}
-
-	for bucket, influxMsg := range points {
-		o.writePoint(bucket, influxMsg)
-	}
-}
-
-func buildVictronPoint(topic string, payload []byte) (string, InfluxMessage, error) {
-	var victronMessage genericPayloadMessage
-	if err := json.Unmarshal(payload, &victronMessage); err != nil {
-		return "", InfluxMessage{}, err
-	}
-
-	splitTopic := strings.Split(topic, "/")
-	if len(splitTopic) < 3 {
-		return "", InfluxMessage{}, fmt.Errorf("topic is not in the correct format: %s", topic)
-	}
-
-	bucket := splitTopic[0]
-	serviceType := splitTopic[2]
-	deviceInstance := ""
-	if len(splitTopic) > 3 {
-		deviceInstance = splitTopic[3]
-	}
-
-	fieldKey := "value"
-	if len(splitTopic) > 4 {
-		fieldKey = strings.Join(splitTopic[4:], "/")
-	}
-
-	point := InfluxMessage{
-		Measurement: serviceType,
-		Tags: map[string]string{
-			"VRM_Portal_ID":   splitTopic[1],
-			"Device_Instance": deviceInstance,
-		},
-		Fields: map[string]interface{}{
-			fieldKey: victronMessage.Value,
-		},
-		Time: time.UnixMilli(int64(victronMessage.Timestamp)),
 	}
 
 	return bucket, point, nil
@@ -362,7 +324,7 @@ func (o *handler) handle(msg *paho.Publish) {
 
 		sensorInfluxMessage := toInfluxMessage(measurement, location, sensorId, sensorMessage)
 
-		writePoint(bucket, sensorInfluxMessage, o.client, o.organization)
+		o.writePoint(bucket, sensorInfluxMessage)
 	} else if strings.HasPrefix(msg.Topic, "victron/") {
 		if !strings.HasSuffix(msg.Topic, "Batteries") {
 			bucket, victronInfluxMessage, err := buildVictronPoint(msg.Topic, msg.Payload)
@@ -370,7 +332,7 @@ func (o *handler) handle(msg *paho.Publish) {
 				fmt.Printf("Victron message could not be parsed (%s): %s", msg.Payload, err)
 				return
 			}
-			writePoint(bucket, victronInfluxMessage, o.client, o.organization)
+			o.writePoint(bucket, victronInfluxMessage)
 		}
 
 	} else {

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -125,7 +125,7 @@ func TestBuildVictronPoint_InvalidInput(t *testing.T) {
 	}
 }
 
-func TestHandle_SkipsVictronBatteriesTopic(t *testing.T) {
+func TestHandle_SkipsVictronTopics(t *testing.T) {
 	h := &handler{organization: "test-org", client: nil}
 	msg := &paho.Publish{
 		Topic: "victron/f29b4d80a6ce/system/0/Batteries",
@@ -243,12 +243,12 @@ func TestHandle_SkipsVictronBatteriesTopic(t *testing.T) {
       "Strength": 29
     }
   }
-}]`),
+}]}`),
 	}
 
 	defer func() {
 		if r := recover(); r != nil {
-			t.Fatalf("expected Batteries topic to be skipped without writing, but handle panicked: %v", r)
+			t.Fatalf("expected skipped topics to not write, but handle panicked: %v", r)
 		}
 	}()
 

--- a/message_handler_test.go
+++ b/message_handler_test.go
@@ -147,6 +147,104 @@ func TestHandle_SkipsVictronBatteriesTopic(t *testing.T) {
 			"timestamp": 1782637542140
 		}`),
 	}
+	msg2 := &paho.Publish{
+		Topic: "victron/f29b4d80a6ce/system/0/Network/Services",
+		Payload: []byte(`{
+			"value": [{
+			"ethernet": {
+    "Wired": {
+      "Address": "10.0.0.10",
+      "Gateway": "10.0.0.1",
+      "Mac": "AA:BB:CC:DD:EE:01",
+      "Method": "dhcp",
+      "Nameservers": ["10.0.0.1"],
+      "Netmask": "255.255.255.0",
+      "Service": "/net/connman/service/ethernet_aabbccddee01_cable",
+      "State": "ready"
+    }
+  },
+  "wifi": {
+    "<hidden>": {
+      "Address": "",
+      "Favorite": "no",
+      "Gateway": "",
+      "Mac": "AA:BB:CC:DD:EE:02",
+      "Method": "",
+      "Nameservers": [],
+      "Netmask": "",
+      "Secured": "yes",
+      "Service": "/net/connman/service/wifi_aabbccddee02_hidden_managed_psk",
+      "State": "idle",
+      "Strength": 30
+    },
+    "WiFi_1": {
+      "Address": "",
+      "Favorite": "no",
+      "Gateway": "",
+      "Mac": "AA:BB:CC:DD:EE:02",
+      "Method": "",
+      "Nameservers": [],
+      "Netmask": "",
+      "Secured": "yes",
+      "Service": "/net/connman/service/wifi_aabbccddee02_ssid01_managed_psk",
+      "State": "idle",
+      "Strength": 32
+    },
+    "WiFi_2": {
+      "Address": "",
+      "Favorite": "no",
+      "Gateway": "",
+      "Mac": "AA:BB:CC:DD:EE:02",
+      "Method": "",
+      "Nameservers": [],
+      "Netmask": "",
+      "Secured": "yes",
+      "Service": "/net/connman/service/wifi_aabbccddee02_ssid02_managed_psk",
+      "State": "idle",
+      "Strength": 59
+    },
+    "WiFi_3": {
+      "Address": "",
+      "Favorite": "no",
+      "Gateway": "",
+      "Mac": "AA:BB:CC:DD:EE:02",
+      "Method": "",
+      "Nameservers": [],
+      "Netmask": "",
+      "Secured": "yes",
+      "Service": "/net/connman/service/wifi_aabbccddee02_ssid03_managed_psk",
+      "State": "idle",
+      "Strength": 59
+    },
+    "WiFi_4": {
+      "Address": "",
+      "Favorite": "no",
+      "Gateway": "",
+      "Mac": "AA:BB:CC:DD:EE:02",
+      "Method": "",
+      "Nameservers": [],
+      "Netmask": "",
+      "Secured": "yes",
+      "Service": "/net/connman/service/wifi_aabbccddee02_ssid04_managed_psk",
+      "State": "idle",
+      "Strength": 37
+    },
+    "WiFi_5": {
+      "Address": "",
+      "Favorite": "no",
+      "Gateway": "",
+      "Mac": "AA:BB:CC:DD:EE:02",
+      "Method": "",
+      "Nameservers": [],
+      "Netmask": "",
+      "Secured": "yes",
+      "Service": "/net/connman/service/wifi_aabbccddee02_ssid05_managed_psk",
+      "State": "idle",
+      "Strength": 29
+    }
+  }
+}]`),
+	}
 
 	defer func() {
 		if r := recover(); r != nil {
@@ -155,4 +253,5 @@ func TestHandle_SkipsVictronBatteriesTopic(t *testing.T) {
 	}()
 
 	h.handle(msg)
+	h.handle(msg2)
 }


### PR DESCRIPTION
This pull request introduces support for configurable InfluxDB async write batching, improves the efficiency and thread safety of InfluxDB writes, and updates the documentation and tests accordingly. The main changes are the addition of new environment variables for write batching, a refactored handler for InfluxDB writes with batching and error handling, and an update to skip additional Victron topics.

**InfluxDB Write Batching Configuration**
- Added new environment variables (`INFLUXDB_WRITE_BATCH_SIZE`, `INFLUXDB_FLUSH_INTERVAL_MS`) to control the size and interval of InfluxDB write batches, with sensible defaults and updated documentation in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R57) [[2]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R34-R36) [[3]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R59-R61) [[4]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R131-R141) [[5]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R167-R178) [[6]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R192-R203)

**InfluxDB Write Handling Refactor**
- Refactored the `handler` struct to manage a map of `WriteAPI` instances per bucket, with thread safety via a mutex, and centralized error logging for write failures. All InfluxDB writes now use the async API, leveraging the batching configuration. [[1]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9R7) [[2]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9R20-R21) [[3]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9R30-R70) [[4]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9R227-R252)

- Removed the old synchronous `writePoint` function and replaced all direct writes with the new, batched, and thread-safe approach. [[1]](diffhunk://#diff-320691328bec27d642dc5096a48ad4d5a25003a1fe234f4b8193d6af22e15138R29-L39) [[2]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9L230-R295) [[3]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9L264-R307) [[4]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9L284-R335)

**Victron Topic Handling**
- Updated the message handler to also skip Victron topics ending in `Network/Services`, in addition to `Batteries`, to avoid unnecessary processing. [[1]](diffhunk://#diff-084163204e955c4813b9c1327152e09e4ea7df68dfffbbeeadfa1b848e77a7d9L284-R335) [[2]](diffhunk://#diff-c229f6c7208662d3bb3455bb5634bba27257b2cf5df1c39e7c3c62e659153154R150-R247)

**Testing**
- Extended the test for skipping Victron topics to cover the new `Network/Services` suffix scenario.

**Documentation**
- Updated the environment variable table and added a section on Influx write tuning options in `README.md`.

These changes improve performance, reliability, and configurability for high-throughput InfluxDB ingestion scenarios.